### PR TITLE
Extend userprofile fields

### DIFF
--- a/components/user-profile/form/update-user-profile-avatar-form/update-user-profile-avatar-form.tsx
+++ b/components/user-profile/form/update-user-profile-avatar-form/update-user-profile-avatar-form.tsx
@@ -7,7 +7,10 @@ import UserProfileAvatar from "@/components/user-profile/details/user-profile-av
 import { Tables } from "@/utils/supabase/database.types";
 
 type UpdateUserProfileAvatarFormProps = {
-  initialValues: Omit<Tables<"userprofiles">, "id" | "email">;
+  initialValues: Omit<
+    Tables<"userprofiles">,
+    "id" | "email" | "first_name" | "last_name" | "date_of_birth"
+  >;
 };
 
 export default function UpdateUserProfileAvatarForm({

--- a/supabase/migrations/20240908035732_add_name_birthday_user_profile_fields.sql
+++ b/supabase/migrations/20240908035732_add_name_birthday_user_profile_fields.sql
@@ -1,0 +1,5 @@
+-- Add first_name, last_name, and date_of_birth to userprofiles
+ALTER TABLE userprofiles
+ADD COLUMN first_name TEXT,
+ADD COLUMN last_name TEXT,
+ADD COLUMN date_of_birth DATE;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -158,11 +158,15 @@ VALUES
 -- Data for Name: userprofiles; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-INSERT INTO "public"."userprofiles" ("id", "username", "email", "avatar_url") VALUES
-	('d21dfe65-42b3-41f8-9481-8d6916782f2a', 'Aang', 'aang@fpa.com', 'd21dfe65-42b3-41f8-9481-8d6916782f2a.jpg'),
-	('006d3f4c-be0e-4361-8cb2-78d1cf032719', 'Kitara', 'kitara@fpa.com', '006d3f4c-be0e-4361-8cb2-78d1cf032719.png'),
-	('24403d5a-668a-41a2-a9e5-1ed740bc5bfc', 'Uppa', 'uppa@fpa.com', '24403d5a-668a-41a2-a9e5-1ed740bc5bfc.jpeg');
+INSERT INTO "public"."userprofiles" ("id", "username", "email", "avatar_url", "first_name", "last_name", "date_of_birth") VALUES
+    -- User with full information
+    ('d21dfe65-42b3-41f8-9481-8d6916782f2a', 'Aang', 'aang@fpa.com', 'd21dfe65-42b3-41f8-9481-8d6916782f2a.jpg', 'Aang', 'Airbender', '2000-12-21'),
 
+    -- User without first name, last name, and date_of_birth
+    ('006d3f4c-be0e-4361-8cb2-78d1cf032719', 'Kitara', 'kitara@fpa.com', '006d3f4c-be0e-4361-8cb2-78d1cf032719.png', NULL, NULL, NULL),
+
+    -- User with some missing fields
+    ('24403d5a-668a-41a2-a9e5-1ed740bc5bfc', 'Uppa', 'uppa@fpa.com', '24403d5a-668a-41a2-a9e5-1ed740bc5bfc.jpeg', 'Uppa', NULL, NULL);
 --
 -- Data for Name: event_organizers; Type: TABLE DATA; Schema: public; Owner: postgres
 --

--- a/utils/supabase/database.types.ts
+++ b/utils/supabase/database.types.ts
@@ -49,14 +49,14 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "tournamentorganizers_tournament_id_fkey"
+            foreignKeyName: "event_organizers_tournament_id_fkey"
             columns: ["event_id"]
             isOneToOne: false
             referencedRelation: "events"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "tournamentorganizers_userprofile_id_fkey"
+            foreignKeyName: "event_organizers_userprofile_id_fkey"
             columns: ["userprofile_id"]
             isOneToOne: false
             referencedRelation: "userprofiles"
@@ -79,14 +79,14 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "tournament_organizers_invitations_tournament_id_fkey"
+            foreignKeyName: "event_organizers_invitations_event_id_fkey"
             columns: ["event_id"]
             isOneToOne: false
             referencedRelation: "events"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "tournament_organizers_invitations_userprofile_id_fkey"
+            foreignKeyName: "event_organizers_invitations_userprofile_id_fkey"
             columns: ["userprofile_id"]
             isOneToOne: false
             referencedRelation: "userprofiles"
@@ -130,7 +130,7 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "tournament_schedules_tournament_id_fkey"
+            foreignKeyName: "event_schedules_event_id_fkey"
             columns: ["event_id"]
             isOneToOne: false
             referencedRelation: "events"
@@ -165,20 +165,29 @@ export type Database = {
       userprofiles: {
         Row: {
           avatar_url: string | null
+          date_of_birth: string | null
           email: string
+          first_name: string | null
           id: string
+          last_name: string | null
           username: string
         }
         Insert: {
           avatar_url?: string | null
+          date_of_birth?: string | null
           email: string
+          first_name?: string | null
           id: string
+          last_name?: string | null
           username: string
         }
         Update: {
           avatar_url?: string | null
+          date_of_birth?: string | null
           email?: string
+          first_name?: string | null
           id?: string
+          last_name?: string | null
           username?: string
         }
         Relationships: [


### PR DESCRIPTION
This PR adds a migration that adds the fields `first_name`, `last_name`, `date_of_birth` to the `userprofiles` table. This is related to requiring to finalise the player profile with required information before the features of the platform can be used completely (like attending or creating events). 